### PR TITLE
fix: Update Slack notification workflow reference to use the main branch

### DIFF
--- a/.github/workflows/notify.yaml
+++ b/.github/workflows/notify.yaml
@@ -9,6 +9,6 @@ on:
 
 jobs:
   notify:
-    uses: subhamay-bhattacharyya-gha/slack-notification-wf/.github/workflows/slack-notify.yaml@feature/GHA-0002-initial-release
+    uses: subhamay-bhattacharyya-gha/slack-notification-wf/.github/workflows/slack-notify.yaml@main
     secrets:
       slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
This pull request makes a small but important update to the workflow configuration by changing the reference for the Slack notification workflow to use the `main` branch instead of a feature branch.

* Updated the `uses` reference in `.github/workflows/notify.yaml` to point to the `main` branch of the Slack notification workflow, ensuring stability and alignment with the latest official release.