### PR TITLE
fix: Update CI workflow to include GCP and frontend paths for pull requests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,13 @@ on:
       - infra/aws/tf/**
       - infra/gcp/tf/**
       - infra/azure/tf/**
+  pull_request:
+    branches: [ main ]
+    paths:
+      - infra/aws/tf/**
+      - infra/gcp/tf/**
+      - infra/azure/tf/**
+      - frontend/**
 
 
 permissions:

--- a/infra/aws/tf/terraform.tfvars
+++ b/infra/aws/tf/terraform.tfvars
@@ -4,5 +4,5 @@ tags = {
   ProjectName = "Cloud Resume Challenge"
   Owner       = "Subhamay Bhattacharyya"
   Env         = "devl"
-  Phase       = "cicd-deployment-1047"
+  Phase       = "cicd-deployment-1504"
 }


### PR DESCRIPTION
This pull request introduces updates to the CI workflow configuration and modifies infrastructure deployment metadata. The most significant changes are the addition of a `pull_request` trigger for the CI workflow and an update to the deployment phase tag in AWS Terraform variables.

**CI Workflow Improvements:**
* Added a `pull_request` trigger to `.github/workflows/ci.yaml`, ensuring CI runs on pull requests to the `main` branch for relevant infrastructure and frontend paths.

**Infrastructure Metadata Update:**
* Changed the `Phase` tag in `infra/aws/tf/terraform.tfvars` from `cicd-deployment-1047` to `cicd-deployment-1504` to reflect the new deployment phase.